### PR TITLE
Lower frequency of Uniswap V4 pool liquidity validation

### DIFF
--- a/simulations/simulators/UniswapV4Simulation.go
+++ b/simulations/simulators/UniswapV4Simulation.go
@@ -375,10 +375,12 @@ func (s *UniswapV4Simulator) simulateTrades(tradesChannel chan models.SimulatedT
 				amountOutAfterDecimalAdjustF64, _ := amountOutFloat.Float64()
 				price, _ := new(big.Float).Quo(amountOutFloat, amountInAfterDecimalAdjust).Float64()
 				log.Infof("amountOut: %v", amountOutAfterDecimalAdjustF64)
+				basePrice := s.priceMap[ep.UnderlyingPair.BaseToken].Price
+				volume := basePrice / price
 
 				trade := models.SimulatedTrade{
 					Price:       price,
-					Volume:      amountOutAfterDecimalAdjustF64,
+					Volume:      volume,
 					QuoteToken:  quoteToken,
 					BaseToken:   baseToken,
 					PoolAddress: poolId.Hex(),


### PR DESCRIPTION
**Description**：
- reduce frequency of pool liquidity checks

**Environment Variable**:
`export DEX_PAIRS=UniswapV4Simulation:Ethereum:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48-0xdAC17F958D2ee523a2206206994597C13D831ec7,UniswapV4Simulation:Ethereum:0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,UniswapV4Simulation:Ethereum:0x111111111117dC0aa78b770fA6A738034120C302-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,UniswapV4Simulation:Ethereum:0x0000000000000000000000000000000000000000-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,UniswapV4Simulation:Ethereum:0x0000000000000000000000000000000000000000-0xdAC17F958D2ee523a2206206994597C13D831ec7,UniswapV4Simulation:Ethereum:0x0000000000000000000000000000000000000000-0x514910771AF9Ca656af840dff83E8264EcF986CA`

**Test Results (Updated on July 25)**:
<img width="1265" height="664" alt="Screenshot 2025-07-25 at 6 47 01 PM" src="https://github.com/user-attachments/assets/70354beb-2238-4da8-8b18-db80aff632c6" />



